### PR TITLE
added missing "isTweening" boolean assignment to takeStepRight()

### DIFF
--- a/chapter-03/03.02-animate-cube.html
+++ b/chapter-03/03.02-animate-cube.html
@@ -126,6 +126,7 @@
                     .to({ x: end }, time )
                 .easing(TWEEN.Easing.Linear.None)
                 .onStart(function () {
+                    isTweening = true;
                     cube.position.y += -widht / 2;
                     cube.position.z += -widht / 2;
                     cubeGeometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, widht / 2, widht / 2));


### PR DESCRIPTION
this exists in the other direction functions. If "right" is called before an exiting right animation has completed , the animation breaks.
